### PR TITLE
PP-1866 Separate out function for Docker tagging

### DIFF
--- a/vars/buildApp.groovy
+++ b/vars/buildApp.groovy
@@ -22,14 +22,4 @@ def call(body) {
 
     def imageName = "${registry}/${docker_repo}/${app}"
     sh "docker build -t ${build_flags} ${imageName}:${version} ."
-
-    if (push_image == true) {
-        // we should use img.tag / img.push here but there is an open issue
-        // see: https://github.com/jenkinsci/docker-workflow-plugin/pull/90
-        sh "docker push ${imageName}:${version}"
-    }
-    if (branch == "master" && push_image == true) {
-        sh "docker tag ${imageName}:${version} ${imageName}:latest-${commit}"
-        sh "docker push ${imageName}:latest-${branch}"
-    }
 }

--- a/vars/dockerTag.groovy
+++ b/vars/dockerTag.groovy
@@ -1,0 +1,35 @@
+#!/usr/bin/groovy
+
+def call(body) {
+    // evaluate the body block, and collect configuration into the object
+    def config = [:]
+    body.resolveStrategy = Closure.DELEGATE_FIRST
+    body.delegate = config
+    body()
+
+    def registry = config.registry ?: "docker.io";
+    def docker_repo =  config.docker_repo ?: "govukpay";
+    def push_image =  config.push_image ?: true;
+    def app = config.app;
+
+    def commit = gitCommit();
+    def branch = gitBranch();
+    def version = "${commit}-${env.BUILD_NUMBER}"
+
+    def imageName = "${registry}/${docker_repo}/${app}"
+
+    if (push_image == true) {
+        // we should use img.tag / img.push here but there is an open issue
+        // see: https://github.com/jenkinsci/docker-workflow-plugin/pull/90
+        sh "docker push ${imageName}:${version}"
+
+        sh "docker tag ${imageName}:${version} govukpay/frontend:${commit}"
+        sh "docker push ${imageName}:${commit}"
+
+        if (branch == "master") {
+            sh "docker tag ${imageName}:${version} ${imageName}:latest-${branch}"
+            sh "docker push ${imageName}:latest-${branch}"
+        }
+    }
+    
+}


### PR DESCRIPTION
Removes Docker tagging code from the `buildApp` function and moves it into a separate `dockerTag` function.

The Jenkinsfile for each project will need to change to accommodate this. For example:

```
    // … more stages …
    stage('Docker Build') {
      steps {
        script {
          buildApp{
            app = "selfservice"
          }
        }
      }
    }
    stage('Test') {
      steps {
        runEndToEnd("selfservice")
      }
    }
    // Call the new function
    stage('Docker Tag') {
      steps {
        script {
          dockerTag{
            app = "selfservice"
          }
        }
      }
    }
   // … more stages …
```
