### PR TITLE
fix git branch in runEndToEnd job

### DIFF
--- a/vars/runEndToEnd.groovy
+++ b/vars/runEndToEnd.groovy
@@ -6,7 +6,7 @@ def call(String app, String tag = null) {
         tag = "${commit}-${env.BUILD_NUMBER}"
     }
 
-    run_zap_tests = (gitBranch == "master") ? true : false
+    run_zap_tests = (gitBranch() == "master") ? true : false
 
     build job: 'run-end-to-end-tests',
         parameters:[


### PR DESCRIPTION
The git branch was not being fetched correctly, so zap tests were not being run on master builds.