### PR TITLE
PP-2855 introduce ProductsEndToEnd pipeline job

### DIFF
--- a/vars/runProductsEndToEnd.groovy
+++ b/vars/runProductsEndToEnd.groovy
@@ -1,0 +1,19 @@
+#!/usr/bin/env groovy
+
+def call(String app, String tag = null) {
+    if (tag == null) {
+        commit = env.GIT_COMMIT ?: gitCommit()
+        tag = "${commit}-${env.BUILD_NUMBER}"
+    }
+
+    run_zap_tests = false
+    test_profile = 'end2end-products'
+
+    build job: 'run-end-to-end-tests',
+        parameters:[
+          string(name: 'MODULE_NAME', value: app),
+          string(name: 'MODULE_TAG', value: tag),
+          booleanParam(name: 'RUN_ZAP_TESTS', value: run_zap_tests),
+          string(name: 'TEST_PROFILE', value: test_profile)
+        ]
+}


### PR DESCRIPTION
This job triggers `run-end-to-end` job with `end2end-products` test profile. Which in turn will trigger only tests tagged for `products`. 
unlike other modules this job does not need to trigger ZAP tests on any test run. (see https://docs.google.com/document/d/1L5spo6vCbU9ThTblFpKDlqefYtHL3LqeCaC0xUKo3U0)
So always keeping to to `false`