### PR TITLE
Fix container tag

### DIFF
--- a/vars/deployEcs.groovy
+++ b/vars/deployEcs.groovy
@@ -6,7 +6,7 @@ def call(String microservice, String aws_profile, String tag = null, boolean tag
     build job: 'deploy-ecs-microservice',
         parameters:[
           string(name: 'MICROSERVICE', value: microservice),
-          string(name: 'CONTAINER_VERSION', value: tag),
+          string(name: 'MICROSERVICE_IMAGE_TAG', value: tag),
           string(name: 'AWS_PROFILE', value: aws_profile),
           booleanParam(name: 'TAG_AFTER_DEPLOYMENT', value: tagAfterDeployment),
           booleanParam(name: 'RUN_TESTS', value: run_tests)


### PR DESCRIPTION
We were passing through a parameter called `CONTAINER_VERSION`
when the job expects `MICROSERVICE_IMAGE_TAG` - see
https://github.com/alphagov/pay-chef/blob/master/cookbooks/pay-ci/templates/default/jenkins_jobs/deploy-ecs-microservice.groovy.erb#L18