### PR TITLE
PP-2996 allow deploy to specify smoke test category

### DIFF
--- a/vars/deploy.groovy
+++ b/vars/deploy.groovy
@@ -4,7 +4,7 @@ def call(String microservice, String aws_profile, String tag = null, boolean tag
     tag = tag ?: gitCommit()
 
     smoke_version = 'v1'
-    if (tag != null) {
+    if (smoke_tags != null) {
         smoke_version = 'v2'
     }
 
@@ -15,7 +15,7 @@ def call(String microservice, String aws_profile, String tag = null, boolean tag
           string(name: 'AWS_PROFILE', value: aws_profile),
           booleanParam(name: 'TAG_AFTER_DEPLOYMENT', value: tagAfterDeployment),
           booleanParam(name: 'RUN_TESTS', value: run_tests),
-          booleanParam(name: 'SMOKE_VERSION', value: smoke_version),
-          booleanParam(name: 'SMOKE_TAGS', value: smoke_tags)
+          string(name: 'SMOKE_VERSION', value: smoke_version),
+          string(name: 'SMOKE_TAGS', value: smoke_tags)
         ]
 }

--- a/vars/deploy.groovy
+++ b/vars/deploy.groovy
@@ -1,14 +1,21 @@
 #!/usr/bin/env groovy
 
-def call(String microservice, String aws_profile, String tag = null, boolean tagAfterDeployment = false, boolean run_tests = true) {
+def call(String microservice, String aws_profile, String tag = null, boolean tagAfterDeployment = false, boolean run_tests = true, smoke_tags = null) {
     tag = tag ?: gitCommit()
-    
+
+    smoke_version = 'v1'
+    if (tag != null) {
+        smoke_version = 'v2'
+    }
+
     build job: 'deploy-pipeline-microservice',
         parameters:[
           string(name: 'MICROSERVICE', value: microservice),
           string(name: 'CONTAINER_VERSION', value: tag),
           string(name: 'AWS_PROFILE', value: aws_profile),
           booleanParam(name: 'TAG_AFTER_DEPLOYMENT', value: tagAfterDeployment),
-          booleanParam(name: 'RUN_TESTS', value: run_tests)
+          booleanParam(name: 'RUN_TESTS', value: run_tests),
+          booleanParam(name: 'SMOKE_VERSION', value: smoke_version),
+          booleanParam(name: 'SMOKE_TAGS', value: smoke_tags)
         ]
 }


### PR DESCRIPTION
So that, microservices can decide what bunch of smoke tests needs triggering after a deployment. This currently defaults to smoke test `v1` which is the current cucumber based smoke tests

Depends on pay-chef, pay-scripts PRs being merged