### PR TITLE
PP-2996 fix smoke tags to be non-null for default jobs

### DIFF
--- a/vars/deploy.groovy
+++ b/vars/deploy.groovy
@@ -1,10 +1,10 @@
 #!/usr/bin/env groovy
 
-def call(String microservice, String aws_profile, String tag = null, boolean tagAfterDeployment = false, boolean run_tests = true, smoke_tags = null) {
+def call(String microservice, String aws_profile, String tag = null, boolean tagAfterDeployment = false, boolean run_tests = true, smoke_tags = '') {
     tag = tag ?: gitCommit()
 
     smoke_version = 'v1'
-    if (smoke_tags != null) {
+    if (smoke_tags != '') {
         smoke_version = 'v2'
     }
 


### PR DESCRIPTION
aparantly, if jenkins job dsl setups default value as '' in stringParam, you cannot pass null in to it. So making `non produts` apps to pass empty instead of null.