### PR TITLE
PP-2996 Allowing pipeline jobs to specify to use PROMOTED_ENV

### DIFF
--- a/vars/deploy.groovy
+++ b/vars/deploy.groovy
@@ -1,12 +1,7 @@
 #!/usr/bin/env groovy
 
-def call(String microservice, String aws_profile, String tag = null, boolean tagAfterDeployment = false, boolean run_tests = true, smoke_tags = '') {
+def call(String microservice, String aws_profile, String tag = null, boolean tagAfterDeployment = false, boolean run_tests = true, smoke_tags = '', boolean promoted_env = false) {
     tag = tag ?: gitCommit()
-
-    smoke_version = 'v1'
-    if (smoke_tags != '') {
-        smoke_version = 'v2'
-    }
 
     build job: 'deploy-pipeline-microservice',
         parameters:[
@@ -15,7 +10,7 @@ def call(String microservice, String aws_profile, String tag = null, boolean tag
           string(name: 'AWS_PROFILE', value: aws_profile),
           booleanParam(name: 'TAG_AFTER_DEPLOYMENT', value: tagAfterDeployment),
           booleanParam(name: 'RUN_TESTS', value: run_tests),
-          string(name: 'SMOKE_VERSION', value: smoke_version),
-          string(name: 'SMOKE_TAGS', value: smoke_tags)
+          string(name: 'SMOKE_TAGS', value: smoke_tags),
+          booleanParam(name: 'PROMOTED_ENV', value: promoted_env)
         ]
 }


### PR DESCRIPTION
This variable `PROMOTED_ENV` must be set to true if you want to run smoke test with non-instance specific cnames (e.g. http://selfservice.test.pymnt.uk). This setting allows microservice to specify whether to use it or not depending on its desired smoke test version.

Note this only matters to test environment.