### PR TITLE
PP-2939 Add job name to run parameterised end to end

### DIFF
--- a/vars/runParameterisedEndToEnd.groovy
+++ b/vars/runParameterisedEndToEnd.groovy
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-def call(String app, String tag = null, testProfile = 'end2end', zapTests = true, acceptTests = true, includes = '', excludes = '') {
+def call(String app, String tag = null, testProfile = 'end2end', zapTests = true, acceptTests = true, includes = '', excludes = '', String jobName = 'run-end-to-end-tests') {
     if (tag == null) {
         commit = env.GIT_COMMIT ?: gitCommit()
         tag = "${commit}-${env.BUILD_NUMBER}"
@@ -8,7 +8,7 @@ def call(String app, String tag = null, testProfile = 'end2end', zapTests = true
 
     run_zap_tests = zapTests && commit == getMasterHeadCommit()
 
-    build job: 'run-end-to-end-tests',
+    build job: jobName,
             parameters: [
                     string(name: 'MODULE_NAME', value: app),
                     string(name: 'MODULE_TAG', value: tag),


### PR DESCRIPTION
- We are going to add a different run end to end job for directdebit (and
  probably products).
  We need to therefore be able to specify the job name in the runParamiterisedEndToEnd
  script.