### PR TITLE
PP-3265 Jenkins jobs converted to use selenium style smoke tests for all [DO NOT MERGE]

### DIFF
--- a/vars/deploy.groovy
+++ b/vars/deploy.groovy
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-def call(String microservice, String aws_profile, String tag = null, boolean tagAfterDeployment = false, boolean run_tests = true, smoke_tags = '', boolean promoted_env = false) {
+def call(String microservice, String aws_profile, String tag = null, boolean tagAfterDeployment = false, boolean run_tests = true, String smoke_tags = 'uk.gov.pay.endtoend.categories.SmokeCardPayments', boolean promoted_env = false) {
     tag = tag ?: gitCommit()
 
     build job: 'deploy-pipeline-microservice',

--- a/vars/deployEcs.groovy
+++ b/vars/deployEcs.groovy
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-def call(String microservice, String aws_profile, String tag = null, boolean tagAfterDeployment = false, boolean run_tests = true, smoke_tags = '', boolean promoted_env = true) {
+def call(String microservice, String aws_profile, String tag = null, boolean tagAfterDeployment = false, boolean run_tests = true, String smoke_tags = 'uk.gov.pay.endtoend.categories.SmokeCardPayments', boolean promoted_env = true) {
     tag = tag ?: gitCommit()
     
     build job: 'deploy-ecs-microservice',


### PR DESCRIPTION
microservices

Smoke tests are being converted from cucumber to selenium so deployments
to ECS must now pass in their smoke test class, or default to all card
payment tests. Changes will need to be made to direct debit connector
and direct debit frontend for their specific smoke test classes.
Products already pass the correct smoke test class