### PR TITLE
PP-3436 Add separate definitions for separate e2e, accept and zap tests

### DIFF
--- a/vars/runAccept.groovy
+++ b/vars/runAccept.groovy
@@ -1,0 +1,18 @@
+#!/usr/bin/env groovy
+
+def call(
+        String app,
+        String tag = null,
+        String jobName = 'run-separate-accept-tests') {
+
+    if (tag == null) {
+        commit = env.GIT_COMMIT ?: gitCommit()
+        tag = "${commit}-${env.BUILD_NUMBER}"
+    }
+
+    build job: jobName,
+            parameters: [
+                    string(name: 'MODULE_NAME', value: app),
+                    string(name: 'MODULE_TAG', value: tag)
+            ]
+}

--- a/vars/runE2E.groovy
+++ b/vars/runE2E.groovy
@@ -1,0 +1,24 @@
+#!/usr/bin/env groovy
+
+def call(
+        String app,
+        String tag = null,
+        testProfile = 'end2end',
+        includes = '',
+        excludes = '',
+        String jobName = 'run-separate-end-to-end-tests') {
+
+    if (tag == null) {
+        commit = env.GIT_COMMIT ?: gitCommit()
+        tag = "${commit}-${env.BUILD_NUMBER}"
+    }
+
+    build job: jobName,
+            parameters: [
+                    string(name: 'MODULE_NAME', value: app),
+                    string(name: 'MODULE_TAG', value: tag),
+                    string(name: 'TEST_PROFILE', value: testProfile),
+                    stringParam(name: 'INCLUDES', value: includes),
+                    stringParam(name: 'EXCLUDES', value: excludes)
+            ]
+}

--- a/vars/runZap.groovy
+++ b/vars/runZap.groovy
@@ -1,0 +1,18 @@
+#!/usr/bin/env groovy
+
+def call(
+        String app,
+        String tag = null,
+        String jobName = 'run-separate-zap-tests') {
+
+    if (tag == null) {
+        commit = env.GIT_COMMIT ?: gitCommit()
+        tag = "${commit}-${env.BUILD_NUMBER}"
+    }
+
+    build job: jobName,
+            parameters: [
+                    string(name: 'MODULE_NAME', value: app),
+                    string(name: 'MODULE_TAG', value: tag)
+            ]
+}


### PR DESCRIPTION
- adds groovy tasks for ruby-based, separately run e2e, accept and zap tests

NOTE: This does not affect any existing pipelines at present as these are all new tasks currently unused by any project.