### PR TITLE
PP-3527 Separate deployment, smoke test and tagging jobs [wip, no merge]

### DIFF
--- a/vars/runCardSmokeTest.groovy
+++ b/vars/runCardSmokeTest.groovy
@@ -1,0 +1,9 @@
+#!/usr/bin/env groovy
+
+def call(String aws_profile = "test", boolean promoted_env = true) {
+  runSmokeTest(
+          smoke_tags: "uk.gov.pay.endtoend.categories.SmokeCardPayments",
+          aws_profile: aws_profile,
+          promoted_env: promoted_env
+  )
+}

--- a/vars/runDirectDebitSmokeTest.groovy
+++ b/vars/runDirectDebitSmokeTest.groovy
@@ -1,0 +1,9 @@
+#!/usr/bin/env groovy
+
+def call(String aws_profile = "test", boolean promoted_env = true) {
+  runSmokeTest(
+          smoke_tags: "uk.gov.pay.endtoend.categories.SmokeDirectDebitPayments",
+          aws_profile: aws_profile,
+          promoted_env: promoted_env
+  )
+}

--- a/vars/runProductsSmokeTest.groovy
+++ b/vars/runProductsSmokeTest.groovy
@@ -1,0 +1,9 @@
+#!/usr/bin/env groovy
+
+def call(String aws_profile = "test", boolean promoted_env = true) {
+  runSmokeTest(
+          smoke_tags: "uk.gov.pay.endtoend.categories.SmokeProducts",
+          aws_profile: aws_profile,
+          promoted_env: promoted_env
+  )
+}

--- a/vars/runSmokeTest.groovy
+++ b/vars/runSmokeTest.groovy
@@ -1,0 +1,11 @@
+#!/usr/bin/env groovy
+
+def call(String smoke_tags, String aws_profile = "test", boolean promoted_env = false) {
+
+  build job: smoke-runv2
+    parameters: [
+      string(name: 'AWS_PROFILE', value: aws_profile),
+      string(name: 'PROMOTED_ENV', value: promoted_env),
+      string(name: 'SMOKE_TAGS', value: smoke_tags)
+    ]
+}

--- a/vars/tagDeployment.groovy
+++ b/vars/tagDeployment.groovy
@@ -1,0 +1,13 @@
+#!/usr/bin/env groovy
+
+def call(String microservice, String aws_profile = "test", String tag = null) {
+  tag = tag ?: gitCommit()
+
+  build job: tag-and-capture-notes-commit-based,
+    parameters: [
+      string(name: 'CALLER_BUILD_STATUS', value: 'success'),
+      string(name: 'ENVIRONMENT', value: aws_profile),
+      string(name: 'COMMIT_HASH', value: tag),
+      string(name: 'SERVICE_TO_TAG', value: microservice)
+    ]
+}

--- a/vars/triggerGraphiteDeployEvent.groovy
+++ b/vars/triggerGraphiteDeployEvent.groovy
@@ -1,0 +1,13 @@
+#!/usr/bin/env groovy
+
+def call(String microservice, String aws_profile = "test", String tag = null) {
+  tag = tag ?: gitCommit()
+
+  build job: deploy_notification
+    parameters: [
+      string(name: 'AWS_PROFILE', value: aws_profile),
+      string(name: 'REPO', value: microservice),
+      string(name: 'GIT_SHA', value: tag),
+      string(name: 'DEPLOYER', value: ${BUILD_USER})
+    ]
+}


### PR DESCRIPTION
We want to be able to run different smoke tests per microservice but cannot currently as it is all bundled in one job. Created generic smoke test function with as much as possible defaulted
Added new jobs for tagging and deploy notification with as much defaulted as possible

solo @belindac