### PR TITLE
PP-3527 Fix smoke test calls

### DIFF
--- a/vars/runCardSmokeTest.groovy
+++ b/vars/runCardSmokeTest.groovy
@@ -2,8 +2,8 @@
 
 def call(String aws_profile = "test", boolean promoted_env = true) {
   runSmokeTest(
-          smoke_tags: "uk.gov.pay.endtoend.categories.SmokeCardPayments",
-          aws_profile: aws_profile,
-          promoted_env: promoted_env
+          "uk.gov.pay.endtoend.categories.SmokeCardPayments",
+          aws_profile,
+          promoted_env
   )
 }

--- a/vars/runDirectDebitSmokeTest.groovy
+++ b/vars/runDirectDebitSmokeTest.groovy
@@ -2,8 +2,8 @@
 
 def call(String aws_profile = "test", boolean promoted_env = true) {
   runSmokeTest(
-          smoke_tags: "uk.gov.pay.endtoend.categories.SmokeDirectDebitPayments",
-          aws_profile: aws_profile,
-          promoted_env: promoted_env
+          "uk.gov.pay.endtoend.categories.SmokeDirectDebitPayments",
+          aws_profile,
+          promoted_env
   )
 }

--- a/vars/runProductsSmokeTest.groovy
+++ b/vars/runProductsSmokeTest.groovy
@@ -2,8 +2,8 @@
 
 def call(String aws_profile = "test", boolean promoted_env = true) {
   runSmokeTest(
-          smoke_tags: "uk.gov.pay.endtoend.categories.SmokeProducts",
-          aws_profile: aws_profile,
-          promoted_env: promoted_env
+          "uk.gov.pay.endtoend.categories.SmokeProducts",
+          aws_profile,
+          promoted_env
   )
 }

--- a/vars/runSmokeTest.groovy
+++ b/vars/runSmokeTest.groovy
@@ -2,10 +2,10 @@
 
 def call(String smoke_tags, String aws_profile = "test", boolean promoted_env = false) {
 
-  build job: smoke-runv2
+  build job: 'run-smoke-test',
     parameters: [
       string(name: 'AWS_PROFILE', value: aws_profile),
-      string(name: 'PROMOTED_ENV', value: promoted_env),
+      booleanParam(name: 'PROMOTED_ENV', value: promoted_env),
       string(name: 'SMOKE_TAGS', value: smoke_tags)
     ]
 }


### PR DESCRIPTION
There is now a base runSmokeTest library fn that calls
the `run-smoke-test` Jenkins job. That job uses the new
version of the smoke script (run-smokev2) if you pass it
`SMOKE_TAGS`. So all this works together, although a tad
complicated to trace through. Once we've transitioned over
we can delete all the old stuff and it will be clearer.