### PR TITLE
PP-3527 Separate deployment, smoke test and tagging jobs

### DIFF
--- a/vars/triggerGraphiteDeployEvent.groovy
+++ b/vars/triggerGraphiteDeployEvent.groovy
@@ -1,6 +1,7 @@
 #!/usr/bin/env groovy
 
 def call(String microservice, String aws_profile = "test", String tag = null) {
+/* Until removed from deployEcs this must not be triggered
   tag = tag ?: gitCommit()
 
   build job: 'trigger-deploy-notification',
@@ -9,4 +10,5 @@ def call(String microservice, String aws_profile = "test", String tag = null) {
       string(name: 'REPO', value: microservice),
       string(name: 'GIT_SHA', value: tag)
     ]
+*/
 }


### PR DESCRIPTION
Until we have converted all the Jenkinsfile deployEcs step into multiple
steps this job cannot be triggered as it will be executed twice.

solo @belindac