### PR TITLE
PP-3527 Separate deployment, smoke test and tagging jobs

### DIFF
--- a/vars/deployEcs.groovy
+++ b/vars/deployEcs.groovy
@@ -7,10 +7,6 @@ def call(String microservice, String aws_profile, String tag = null, boolean tag
         parameters:[
           string(name: 'MICROSERVICE', value: microservice),
           string(name: 'MICROSERVICE_IMAGE_TAG', value: tag),
-          string(name: 'AWS_PROFILE', value: aws_profile),
-          booleanParam(name: 'TAG_AFTER_DEPLOYMENT', value: tagAfterDeployment),
-          booleanParam(name: 'RUN_TESTS', value: run_tests),
-          string(name: 'SMOKE_TAGS', value: smoke_tags),
-          booleanParam(name: 'PROMOTED_ENV', value: promoted_env)
+          string(name: 'AWS_PROFILE', value: aws_profile)
         ]
 }


### PR DESCRIPTION
All Jenkins files have been converted to use separated jobs so we can
now remove the arguments that were used for those jobs.

TODO: Remove all the tagging and smoke parameter values from all the
Jenkins files and then we can remove the method parameters

solo @belindac