### PR TITLE
PP-3596 temporarily disabling products smoke tests

### DIFF
--- a/vars/runProductsSmokeTest.groovy
+++ b/vars/runProductsSmokeTest.groovy
@@ -1,9 +1,4 @@
 #!/usr/bin/env groovy
 
 def call(String aws_profile = "test", boolean promoted_env = true) {
-  runSmokeTest(
-          "uk.gov.pay.endtoend.categories.SmokeProducts",
-          aws_profile,
-          promoted_env
-  )
 }


### PR DESCRIPTION
Temporarily disabling products smoke tests, to unblock the pipeline.

This has been tested using a branch when I fiddled around with the Jenkinsfile.