### PR TITLE
Revert merge pull request #58 to re-instate disabled products smoke tests

### DIFF
--- a/vars/runProductsSmokeTest.groovy
+++ b/vars/runProductsSmokeTest.groovy
@@ -1,4 +1,9 @@
 #!/usr/bin/env groovy
 
 def call(String aws_profile = "test", boolean promoted_env = true) {
+  runSmokeTest(
+          "uk.gov.pay.endtoend.categories.SmokeProducts",
+          aws_profile,
+          promoted_env
+  )
 }


### PR DESCRIPTION
This reverts commit 83c19a6ca69bb8e3f701edbf9d0c799af9128a5c, reversing
changes made to 1bad374c2fb1dff42696027785327e1f9444a99d which disabled products smoke tests. Since the problem has disappeared after rebooting Jenkins is is now a safe thing to do.