### PR TITLE
PP-3636 Add Cypress task to library

### DIFF
--- a/resources/cypress/cypress.yml
+++ b/resources/cypress/cypress.yml
@@ -1,0 +1,33 @@
+version: '2.1'
+
+networks:
+  pymnt_network:
+    external:
+      name: ${NETWORK_NAME}
+services:
+  app_under_test:
+    image: govukpay/${IMAGE}:${TAG}
+    env_file: ${WORKSPACE}/cypress/test.env
+    environment:
+      PORT: 3000
+    networks:
+      pymnt_network:
+        aliases:
+          - app-under-test.internal.pymnt.localdomain
+    mem_limit: 1G
+    logging:
+      driver: "json-file"
+
+  cypress:
+    image: govukpay/cypress:6
+    networks:
+      - pymnt_network
+    environment:
+      CYPRESS_baseUrl: http://app-under-test.internal.pymnt.localdomain:3000
+    volumes:
+      - ${WORKSPACE}/cypress:/app/cypress
+      - ${WORKSPACE}/cypress.json:/app/cypress.json
+    depends_on:
+      - app_under_test
+    logging:
+      driver: "json-file"

--- a/resources/cypress/cypress.yml
+++ b/resources/cypress/cypress.yml
@@ -10,6 +10,12 @@ services:
     env_file: ${WORKSPACE}/cypress/test.env
     environment:
       PORT: 3000
+      CONNECTOR_URL: http://pact-stub.internal.pymnt.localdomain:8080
+      DIRECT_DEBIT_CONNECTOR_URL: http://pact-stub.internal.pymnt.localdomain:8080
+      PUBLIC_AUTH_BASE: http://pact-stub.internal.pymnt.localdomain:8080
+      PUBLIC_AUTH_URL: http://pact-stub.internal.pymnt.localdomain:8080/v1/frontend/auth
+      ADMINUSERS_URL: http://pact-stub.internal.pymnt.localdomain:8080
+      PRODUCTS_URL: http://pact-stub.internal.pymnt.localdomain:8080
     networks:
       pymnt_network:
         aliases:
@@ -31,3 +37,21 @@ services:
       - app_under_test
     logging:
       driver: "json-file"
+    mem_limit: 2G
+
+  stub:
+    image: pactfoundation/pact-stub-server
+    networks:
+      pymnt_network:
+        aliases:
+          - pact-stub.internal.pymnt.localdomain
+    entrypoint:
+      - -p
+      - 8080
+      - -d
+      - pacts
+    volumes:
+      - ${WORKSPACE}/pacts:/app/pacts
+    mem_limit: 1G
+
+

--- a/vars/cypress.groovy
+++ b/vars/cypress.groovy
@@ -1,0 +1,30 @@
+#!/usr/bin/env groovy
+
+def runTests(String app = null, String tag = null) {
+
+    commit = env.GIT_COMMIT ?: gitCommit()
+    library = new File(getClass().protectionDomain.codeSource.location.path).getParentFile().parent
+
+    env.COMPOSE_FILE = "${library}/resources/cypress/cypress.yml"
+    env.COMPOSE_PROJECT_NAME = env.BUILD_TAG
+    env.NETWORK_NAME = env.BUILD_TAG
+    env.IMAGE = app
+    env.TAG = (tag == null) ? "${commit}-${env.BUILD_NUMBER}" : tag
+
+    sh """
+            docker network create ${env.NETWORK_NAME}
+            docker-compose pull --ignore-pull-failures
+            docker-compose up -d
+            docker-compose exec -T cypress ./ready.sh
+            docker-compose exec -T cypress ./run-cypress.sh
+       """
+}
+
+def cleanUp() {
+    sh """
+          set +e
+          docker-compose down
+          docker network rm ${env.NETWORK_NAME}
+          set -e
+       """
+}


### PR DESCRIPTION
Adds task for running cypress tests via docker-compose to pay-jenkins-library 

They can be added to a repo with cypress tests by adding the following to a Jenkinsfile after the build step:

```
stage('Integration Test') {
      steps {
        script {
          cypress.runTests 'selfservice'
        }
      }
      post {
        always {
          script {
            cypress.cleanUp()
          }
        }
        failure {
          archive 'cypress/videos/*.mp4'
          archive 'cypress/screenshots/*.png'
          postMetric("selfservice.integration-tests.failure", 1)
        }
      }
    }
```