### PR TITLE
PP-3614 publish pact files build

### DIFF
--- a/vars/buildAppWithMetrics.groovy
+++ b/vars/buildAppWithMetrics.groovy
@@ -10,13 +10,13 @@ def call(body) {
     body.delegate = config
     body()
 
-    def registry = config.registry ?: "docker.io";
-    def docker_repo =  config.docker_repo ?: "govukpay" ;
-    def push_image =  config.push_image ?: true ;
-    def disable_docker_cache =  config.disable_docker_cache ?: false ;
-    def app = config.app ;
-    def build_flags = "";
-    def commit = gitCommit();
+    def registry = config.registry ?: "docker.io"
+    def docker_repo =  config.docker_repo ?: "govukpay"
+    def disable_docker_cache =  config.disable_docker_cache ?: false
+    def app = config.app
+    def build_flags = ""
+    def commit = gitCommit()
+    def branch_name = gitBranchName()
     def version = "${commit}-${env.BUILD_NUMBER}"
 
     if (disable_docker_cache == true) {
@@ -26,8 +26,7 @@ def call(body) {
     if (app == "frontend" || app == "selfservice" || app == 'products-ui' || app == 'directdebit-frontend') {
         def buildImageName = "build-and-test-${app}"
         sh "docker build --file docker/build_and_test.Dockerfile -t ${buildImageName}:${version} ."
-        sh "docker run --volume \$(pwd):/app ${buildImageName}:${version}"
-
+        sh "docker run --env PACT_CONSUMER_VERSION=${commit} --env PACT_CONSUMER_TAG=${branch_name} --volume \$(pwd):/app ${buildImageName}:${version}"
         Date unitTestsStopTime = new Date()
         long unitTestsDiff = (unitTestsStopTime.getTime() - startTime.getTime()) / 1000;
 

--- a/vars/buildAppWithMetrics.groovy
+++ b/vars/buildAppWithMetrics.groovy
@@ -11,8 +11,8 @@ def call(body) {
     body()
 
     def registry = config.registry ?: "docker.io"
-    def docker_repo =  config.docker_repo ?: "govukpay"
-    def disable_docker_cache =  config.disable_docker_cache ?: false
+    def docker_repo = config.docker_repo ?: "govukpay"
+    def disable_docker_cache = config.disable_docker_cache ?: false
     def app = config.app
     def build_flags = ""
     def commit = gitCommit()
@@ -26,7 +26,13 @@ def call(body) {
     if (app == "frontend" || app == "selfservice" || app == 'products-ui' || app == 'directdebit-frontend') {
         def buildImageName = "build-and-test-${app}"
         sh "docker build --file docker/build_and_test.Dockerfile -t ${buildImageName}:${version} ."
-        sh "docker run --env PACT_CONSUMER_VERSION=${commit} --env PACT_CONSUMER_TAG=${branch_name} --volume \$(pwd):/app ${buildImageName}:${version}"
+        withCredentials([
+                string(credentialsId: 'pact_broker_username', variable: 'PACT_BROKER_USERNAME'),
+                string(credentialsId: 'pact_broker_password', variable: 'PACT_BROKER_PASSWORD')]
+        ) {
+            sh "docker run --env PACT_BROKER_URL=https://pact-broker-test.cloudapps.digital --env PACT_CONSUMER_VERSION=${commit} --env PACT_BROKER_USERNAME=${PACT_BROKER_USERNAME} " +
+                    "--env PACT_BROKER_PASSWORD=${PACT_BROKER_PASSWORD} --env PACT_CONSUMER_TAG=${branch_name} --volume \$(pwd):/app ${buildImageName}:${version}"
+        }
         Date unitTestsStopTime = new Date()
         long unitTestsDiff = (unitTestsStopTime.getTime() - startTime.getTime()) / 1000;
 

--- a/vars/gitBranchName.groovy
+++ b/vars/gitBranchName.groovy
@@ -1,3 +1,3 @@
 String call() {
-  sh(script: "git rev-parse HEAD | git branch -a --contains | sed -n 2p | | cut -d'/' -f 3", returnStdout: true).trim()
+  sh(script: "git rev-parse HEAD | git branch -a --contains | sed -n 2p | cut -d'/' -f 3", returnStdout: true).trim()
 }

--- a/vars/gitBranchName.groovy
+++ b/vars/gitBranchName.groovy
@@ -1,0 +1,3 @@
+String call() {
+  sh(script: "git rev-parse HEAD | git branch -a --contains | sed -n 2p | | cut -d'/' -f 3", returnStdout: true).trim()
+}


### PR DESCRIPTION
- Add commit sha as PACT_CONSUMER_VERSION and PACT_CONSUMER_TAG as the first branch name related to this commit.

-  Since Jenkins checkout PR's using the commit sha and not a branch name, it needs to be extracted somehow, and the easiest way is finding the first branch that contains that commit, since PR's are build with new commits is unexpected that this will collide with others, an ouput example of a `git branch -a --contains {commit_sha} is:

		`* (HEAD detached at 8b07ab7)
		  remote/origin/PP-3614-publish-pact-file-on-pr-build`

    so it is extracted directly the second line of this output (3rd split by '/'), in case there is collision with other branches containing the same sha (it should not happen) it will still use the first branch with the given commit sha ignoring the others.