### PR TITLE
PP-3641 Stop running accept tests

### DIFF
--- a/vars/runAccept.groovy
+++ b/vars/runAccept.groovy
@@ -5,20 +5,6 @@ def call(
         String tag = null,
         String pay_scripts_branch = null) {
 
-    commit = env.GIT_COMMIT ?: gitCommit()
-
-    if (tag == null) {
-        tag = "${commit}-${env.BUILD_NUMBER}"
-    }
-
-    if (pay_scripts_branch == null) {
-        pay_scripts_branch = (app == 'scripts') ? commit : 'master'
-    }
-
-    build job: 'run-separate-accept-tests',
-            parameters: [
-                    string(name: 'MODULE_NAME', value: app),
-                    string(name: 'MODULE_TAG', value: tag),
-                    string(name: 'PAY_SCRIPTS_BRANCH', value: pay_scripts_branch)
-            ]
+    // DISABLED - deemed to be utterly useless
+    // https://pay-team-manual.cloudapps.digital/arch/adr-002-deprecation-of-pay-accepttests/
 }


### PR DESCRIPTION
See https://pay-team-manual.cloudapps.digital/arch/adr-002-deprecation-of-pay-accepttests/