### PR TITLE
PP-3621: Tag consumer pact job

### DIFF
--- a/vars/tagConsumerPact.groovy
+++ b/vars/tagConsumerPact.groovy
@@ -1,0 +1,18 @@
+#!/usr/bin/env groovy
+def call( String consumerName,
+          String consumerVersion,
+          String tag) {
+
+    withCredentials([
+            string(credentialsId: 'pact_broker_username', variable: 'PACT_BROKER_USERNAME'),
+            string(credentialsId: 'pact_broker_password', variable: 'PACT_BROKER_PASSWORD')]
+    ) {
+        STATUS = sh (
+                script: "curl -H \"Content-Type: application/json\" -X PUT -k --user ${PACT_BROKER_USERNAME}:${PACT_BROKER_PASSWORD} https://pact-broker-test.cloudapps.digital/pacticipants/${consumerName}/versions/${consumerVersion}/tags/${tag} --write-out \'%{http_code}\' -s -o /dev/null",
+                returnStdout: true
+        ).trim()
+        if (!["200","201"].contains(STATUS)) {
+            error("Tagging consumer pact did not return 200 OK or 201 CREATED")
+        }
+    }
+}


### PR DESCRIPTION
This job is meant to be called on a consumer's post-deploy. The way our code is
structured, in reality this job is only applicable for deploys to the "test"
environment. The job to tag in staging and prod will be in pay-chef repo.

@oswaldquek