### PR TITLE
PP-3776 Temporarily disable direct debit smoke tests

### DIFF
--- a/vars/runDirectDebitSmokeTest.groovy
+++ b/vars/runDirectDebitSmokeTest.groovy
@@ -1,9 +1,12 @@
 #!/usr/bin/env groovy
 
 def call(String aws_profile = "test", boolean promoted_env = true) {
-  runSmokeTest(
-          "uk.gov.pay.endtoend.categories.SmokeDirectDebitPayments",
-          aws_profile,
-          promoted_env
-  )
+  //Temporarily disabling to unblock pipeline, to allow diagnosis of 
+  //DD connection problems
+
+  //runSmokeTest(
+  //        "uk.gov.pay.endtoend.categories.SmokeDirectDebitPayments",
+  //        aws_profile,
+  //        promoted_env
+  //)
 }


### PR DESCRIPTION
DD connector is broken, and DD team want to take some time to
diagnose the issue. While they do that we are disabling this smoke
test, so as not to block the pipeline. This will mean that
DD smoke tests won't be run post deploy to test, so some apps may
get to staging in a 'broken' state (though this is unlikely). If
they do, staging smoke tests will catch them.