### PR TITLE
bau: Remove latest tag when querying to check for pact compatibility

### DIFF
--- a/vars/checkPactCompatibility.groovy
+++ b/vars/checkPactCompatibility.groovy
@@ -7,7 +7,7 @@ def call( String service,
             string(credentialsId: 'pact_broker_password', variable: 'PACT_BROKER_PASSWORD')]
     ) {
         def resultJson = sh(
-                script: "curl -H \'Accept: application/json, application/hal+json\' --user ${PACT_BROKER_USERNAME}:${PACT_BROKER_PASSWORD} -g -s \'https://pact-broker-test.cloudapps.digital/matrix?q[][pacticipant]=${service}&q[][version]=${gitSha}&latestby=cvp&latest=true&tag=${tag}\'",
+                script: "curl -H \'Accept: application/json, application/hal+json\' --user ${PACT_BROKER_USERNAME}:${PACT_BROKER_PASSWORD} -g -s \'https://pact-broker-test.cloudapps.digital/matrix?q[][pacticipant]=${service}&q[][version]=${gitSha}&latestby=cvp&tag=${tag}\'",
                 returnStdout: true
         ).trim()
         def isDeployable = sh(


### PR DESCRIPTION
The latest=true query causes some builds to fail, even though the pact between
two services may be satisfied. We don't use the latest tag ever, only the
versions (git shas) so removing this.

@oswaldquek