### PR TITLE
bau: Specify a flag to publish verification results to the pact broker

### DIFF
--- a/vars/runProviderContractTests.groovy
+++ b/vars/runProviderContractTests.groovy
@@ -8,6 +8,6 @@ def call() {
             string(credentialsId: 'pact_broker_username', variable: 'PACT_BROKER_USERNAME'),
             string(credentialsId: 'pact_broker_password', variable: 'PACT_BROKER_PASSWORD')]
     ) {
-        sh "mvn test -DrunContractTests -DPACT_CONSUMER_TAG=master -DPACT_BROKER_USERNAME=${PACT_BROKER_USERNAME} -DPACT_BROKER_PASSWORD=${PACT_BROKER_PASSWORD} -DPROVIDER_SHA=${commit}"
+        sh "mvn test -DrunContractTests -DPACT_CONSUMER_TAG=master -DPACT_BROKER_USERNAME=${PACT_BROKER_USERNAME} -DPACT_BROKER_PASSWORD=${PACT_BROKER_PASSWORD} -DPROVIDER_SHA=${commit} -Dpact.verifier.publishResults=true"
     }
 }


### PR DESCRIPTION
We have (or will be upgrading) java projects to use version 3.5.18 of the pact
jvm provider library, which disables publishing of verification result to the
pact broker by default. See https://github.com/DiUS/pact-jvm/issues/695. We
want to do this so results don't get accidentally published from development
machines.So we have to set the pact.verifier.publishResults to true here.

@oswaldquek