### PR TITLE
bau: fix gitBranchName function

### DIFF
--- a/vars/gitBranchName.groovy
+++ b/vars/gitBranchName.groovy
@@ -1,3 +1,3 @@
 String call() {
-  sh(script: "git rev-parse HEAD | git branch -a --contains | sed -n 2p | cut -d'/' -f 3", returnStdout: true).trim()
+  sh(script: "git symbolic-ref HEAD|sed -e 's|refs/heads/||'", returnStdout: true).trim()
 }


### PR DESCRIPTION
For some reason gitBranchName hasn't been working and getting spurious branch names.

`git rev-parse HEAD | git branch -a --contains` yields something like:
```
  bau-dont-publish-verification-by-default
* bau-fix-gitBranchName
  bau-remove-latest-tag
  bau-update-parameter-names
  master
```
we then grep the line containing `*` and use a `cut` to get the branch name.

@oswaldquek