### PR TITLE
Revert "bau: fix gitBranchName function"

### DIFF
--- a/vars/gitBranchName.groovy
+++ b/vars/gitBranchName.groovy
@@ -1,3 +1,3 @@
 String call() {
-  sh(script: "git symbolic-ref HEAD|sed -e 's|refs/heads/||'", returnStdout: true).trim()
+  sh(script: "git rev-parse HEAD | git branch -a --contains | sed -n 2p | cut -d'/' -f 3", returnStdout: true).trim()
 }


### PR DESCRIPTION
This reverts commit 8acad68b2c50a36b459d34ce3b67abeb7143eb9e.
This doesn't work in that it yields nothing in the pay-selfservice build :(