### PR TITLE
Script to call pay scripts update

### DIFF
--- a/vars/runLocalPayScriptsUpdate.groovy
+++ b/vars/runLocalPayScriptsUpdate.groovy
@@ -1,0 +1,5 @@
+#!/usr/bin/env groovy
+
+def call() {
+    build job: 'run-scheduled-pay-scripts-update', parameters: []
+}


### PR DESCRIPTION
Pay-scripts master merges fail because the local repo is not up to date.
This allows us to call the update job before the master tests are run.

solo @belindac