### PR TITLE
PP-4082: The PACT_CONSUMER_TAG property is no longer required

### DIFF
--- a/vars/runProviderContractTests.groovy
+++ b/vars/runProviderContractTests.groovy
@@ -8,6 +8,6 @@ def call() {
             string(credentialsId: 'pact_broker_username', variable: 'PACT_BROKER_USERNAME'),
             string(credentialsId: 'pact_broker_password', variable: 'PACT_BROKER_PASSWORD')]
     ) {
-        sh "mvn test -DrunContractTests -DPACT_CONSUMER_TAG=master -DPACT_BROKER_USERNAME=${PACT_BROKER_USERNAME} -DPACT_BROKER_PASSWORD=${PACT_BROKER_PASSWORD} -DPROVIDER_SHA=${commit} -Dpact.verifier.publishResults=true"
+        sh "mvn test -DrunContractTests -DPACT_BROKER_USERNAME=${PACT_BROKER_USERNAME} -DPACT_BROKER_PASSWORD=${PACT_BROKER_PASSWORD} -DPROVIDER_SHA=${commit} -Dpact.verifier.publishResults=true"
     }
 }


### PR DESCRIPTION
Provider tests are now hard coded to run pacts tagged with "master", "test",
"staging" and "production". See
https://github.com/alphagov/pay-connector/commit/667dea30defc7c3f9a5ac0bfa653c532ae206fc9
as an example.

@oswaldquek