### PR TITLE
PP-4096 Using previous version of pack-stub-server

### DIFF
--- a/resources/cypress/cypress.yml
+++ b/resources/cypress/cypress.yml
@@ -30,7 +30,7 @@ services:
     mem_limit: 2G
 
   stub:
-    image: pactfoundation/pact-stub-server
+    image: pactfoundation/pact-stub-server:v0.0.10
     entrypoint:
       - "/app/pact-stub-server"
       - "-p"


### PR DESCRIPTION
 - Seems that the `latest` version of `pact-stub-server` is failing with our
 cypress tests for `Selfservice` which cause the stub server to freeze and stop
 processing/accepting any new requests. This manifests itself as time-outs during
 the cypress tests for `Selfservice` during the login page tests.
 - Changing the `pact-stub-server` to reference the previous version
 `v0.0.10'(which works locally on multiple machines) to unblock build of SelfService.
 - We'll need to figure out why this is failing before this verison of `pact-stub-server`
 is removed and then revert back to using `latest` tag.
 - Note that previously passing cypress tests now fail with the latest
 pact-stub-server and this doesn't appear to be something introduced by the
 latest `Selfservice` changes; likely something that has changed with the
 pact stub server.