### PR TITLE
Revert "PP-4082: The PACT_CONSUMER_TAG property is no longer required"

### DIFF
--- a/vars/runProviderContractTests.groovy
+++ b/vars/runProviderContractTests.groovy
@@ -8,6 +8,6 @@ def call() {
             string(credentialsId: 'pact_broker_username', variable: 'PACT_BROKER_USERNAME'),
             string(credentialsId: 'pact_broker_password', variable: 'PACT_BROKER_PASSWORD')]
     ) {
-        sh "mvn test -DrunContractTests -DPACT_BROKER_USERNAME=${PACT_BROKER_USERNAME} -DPACT_BROKER_PASSWORD=${PACT_BROKER_PASSWORD} -DPROVIDER_SHA=${commit} -Dpact.verifier.publishResults=true"
+        sh "mvn test -DrunContractTests -DPACT_CONSUMER_TAG=master -DPACT_BROKER_USERNAME=${PACT_BROKER_USERNAME} -DPACT_BROKER_PASSWORD=${PACT_BROKER_PASSWORD} -DPROVIDER_SHA=${commit} -Dpact.verifier.publishResults=true"
     }
 }


### PR DESCRIPTION
This reverts commit 275cddf6def177dbe1eab4aff8ab1d6cdcd58cf3.

We actually still need the PACT_CONSUMER_TAG because provider PR builds need to
know the branch name via the PACT_CONSUMER_TAG.