### PR TITLE
PP-4025 Master branch required for PRs

### DIFF
--- a/vars/getMasterHeadCommit.groovy
+++ b/vars/getMasterHeadCommit.groovy
@@ -1,6 +1,6 @@
 String call() {
     if (env.MASTER_HEAD_COMMIT == null) {
-        env.MASTER_HEAD_COMMIT =   sh(script: "git rev-parse origin/master", returnStdout: true).trim()
+        env.MASTER_HEAD_COMMIT =   sh(script: "git fetch origin +refs/heads/master:refs/remotes/origin/master; git rev-parse origin/master", returnStdout: true).trim()
     }
     env.MASTER_HEAD_COMMIT
 }


### PR DESCRIPTION
With the upgrade of the Github plugins, only the PR branch is fetched
and the build breaks trying to get the master head commit. Until the
job-dsl plugin supports setting ref specs we need to get the master
branch for this function

solo @belindac