### PR TITLE
PP-4213 Fix products e2e

### DIFF
--- a/vars/runProductsE2E.groovy
+++ b/vars/runProductsE2E.groovy
@@ -3,7 +3,7 @@
 def call(
         String app = null,
         String tag = null,
-        String pay_scripts_branch = 'master') {
+        String pay_scripts_branch = null) {
 
     commit = env.GIT_COMMIT ?: gitCommit()
 


### PR DESCRIPTION
We were defaulting branch to `master` in products e2e script.
This meant it was impossible to build pay-scripts in certain
circumstances. Changing default to null to match other e2e scripts.