### PR TITLE
BAU: Factor out duplicate code in run*E2E steps

### DIFF
--- a/vars/runAppE2E.groovy
+++ b/vars/runAppE2E.groovy
@@ -8,18 +8,13 @@ def call(
 
     commit = env.GIT_COMMIT ?: gitCommit()
 
-    if (tag == null) {
-        tag = "${commit}-${env.BUILD_NUMBER}"
-    }
-
-    if (pay_scripts_branch == null) {
-        pay_scripts_branch = (app == 'scripts') ? commit : 'master'
-    }
+    git_tag = tag ?: "${commit}-${env.BUILD_NUMBER}"
+    job_pay_scripts_branch = pay_scripts_branch ?: (app == 'scripts') ? commit : 'master'
 
     build job: job_name,
             parameters: [
                     string(name: 'MODULE_NAME', value: app),
-                    string(name: 'MODULE_TAG', value: tag),
-                    string(name: 'PAY_SCRIPTS_BRANCH', value: pay_scripts_branch)
+                    string(name: 'MODULE_TAG', value: git_tag),
+                    string(name: 'PAY_SCRIPTS_BRANCH', value: job_pay_scripts_branch)
             ]
 }

--- a/vars/runAppE2E.groovy
+++ b/vars/runAppE2E.groovy
@@ -1,0 +1,25 @@
+#!/usr/bin/env groovy
+
+def call(
+        String app = null,
+        String job_name = null,
+        String tag = null,
+        String pay_scripts_branch = null) {
+
+    commit = env.GIT_COMMIT ?: gitCommit()
+
+    if (tag == null) {
+        tag = "${commit}-${env.BUILD_NUMBER}"
+    }
+
+    if (pay_scripts_branch == null) {
+        pay_scripts_branch = (app == 'scripts') ? commit : 'master'
+    }
+
+    build job: job_name,
+            parameters: [
+                    string(name: 'MODULE_NAME', value: app),
+                    string(name: 'MODULE_TAG', value: tag),
+                    string(name: 'PAY_SCRIPTS_BRANCH', value: pay_scripts_branch)
+            ]
+}

--- a/vars/runCardPaymentsE2E.groovy
+++ b/vars/runCardPaymentsE2E.groovy
@@ -4,22 +4,5 @@ def call(
         String app = null,
         String tag = null,
         String pay_scripts_branch = null) {
-
-    commit = env.GIT_COMMIT ?: gitCommit()
-
-    if (tag == null) {
-        tag = "${commit}-${env.BUILD_NUMBER}"
-    }
-
-    if (pay_scripts_branch == null) {
-        pay_scripts_branch = (app == 'scripts') ? commit : 'master'
-    }
-
-    build job: 'run-end-to-end-card-payment-tests',
-            parameters: [
-                    string(name: 'MODULE_NAME', value: app),
-                    string(name: 'MODULE_TAG', value: tag),
-                    string(name: 'PAY_SCRIPTS_BRANCH', value: pay_scripts_branch)
-            ]
-
+    runAppE2E(app, 'run-end-to-end-card-payment-tests', tag, pay_scripts_branch)
 }

--- a/vars/runDirectDebitE2E.groovy
+++ b/vars/runDirectDebitE2E.groovy
@@ -4,21 +4,5 @@ def call(
         String app = null,
         String tag = null,
         String pay_scripts_branch = null) {
-
-    commit = env.GIT_COMMIT ?: gitCommit()
-
-    if (tag == null) {
-        tag = "${commit}-${env.BUILD_NUMBER}"
-    }
-
-    if (pay_scripts_branch == null) {
-        pay_scripts_branch = (app == 'scripts') ? commit : 'master'
-    }
-
-    build job: 'run-end-to-end-direct-debit-tests',
-            parameters: [
-                    string(name: 'MODULE_NAME', value: app),
-                    string(name: 'MODULE_TAG', value: tag),
-                    string(name: 'PAY_SCRIPTS_BRANCH', value: pay_scripts_branch)
-            ]
+    runAppE2E(app, 'run-end-to-end-direct-debit-tests', tag, pay_scripts_branch)
 }

--- a/vars/runProductsE2E.groovy
+++ b/vars/runProductsE2E.groovy
@@ -4,21 +4,5 @@ def call(
         String app = null,
         String tag = null,
         String pay_scripts_branch = null) {
-
-    commit = env.GIT_COMMIT ?: gitCommit()
-
-    if (tag == null) {
-        tag = "${commit}-${env.BUILD_NUMBER}"
-    }
-
-    if (pay_scripts_branch == null) {
-        pay_scripts_branch = (app == 'scripts') ? commit : 'master'
-    }
-
-    build job: 'run-end-to-end-products-tests',
-            parameters: [
-                    string(name: 'MODULE_NAME', value: app),
-                    string(name: 'MODULE_TAG', value: tag),
-                    string(name: 'PAY_SCRIPTS_BRANCH', value: pay_scripts_branch)
-            ]
+    runAppE2E(app, 'run-end-to-end-products-tests', tag, pay_scripts_branch)
 }


### PR DESCRIPTION
Make the run*E2E pipeline steps use a common codebase rather than duplicating each other.