### PR TITLE
bau: Publish verification when running provider test in a consumer build

### DIFF
--- a/vars/runPactProviderTests.groovy
+++ b/vars/runPactProviderTests.groovy
@@ -13,7 +13,7 @@ def call( String providerProjectName,
             set -ue pipefail
             cd ${providerProjectName}
             export DOCKER_HOST=unix:///var/run/docker.sock
-            mvn clean test -DrunContractTests -DPACT_BROKER_USERNAME=${PACT_BROKER_USERNAME} -DPACT_BROKER_PASSWORD=${PACT_BROKER_PASSWORD} -DPACT_CONSUMER_TAG=${consumerTag} -DPROVIDER_SHA=${providerSha}
+            mvn clean test -DrunContractTests -DPACT_BROKER_USERNAME=${PACT_BROKER_USERNAME} -DPACT_BROKER_PASSWORD=${PACT_BROKER_PASSWORD} -DPACT_CONSUMER_TAG=${consumerTag} -DPROVIDER_SHA=${providerSha} -Dpact.verifier.publishResults=true
            """
     }
 }


### PR DESCRIPTION
This resolves an issue where a new interaction is added in the consumer pact,
but does not require a change in the provider. When this happens, when the
provider contract test is run as part of the consumer build, the verification
result should be published. Otherwise, the consumer build will fail at the
deploy stage as no provider has verified the new interaction that was added in
the first place.

@oswaldquek