### PR TITLE
bau: Use correct env var to provide the provider version

### DIFF
--- a/vars/runPactProviderTests.groovy
+++ b/vars/runPactProviderTests.groovy
@@ -13,7 +13,7 @@ def call( String providerProjectName,
             set -ue pipefail
             cd ${providerProjectName}
             export DOCKER_HOST=unix:///var/run/docker.sock
-            mvn clean test -DrunContractTests -DPACT_BROKER_USERNAME=${PACT_BROKER_USERNAME} -DPACT_BROKER_PASSWORD=${PACT_BROKER_PASSWORD} -DPACT_CONSUMER_TAG=${consumerTag} -DPROVIDER_SHA=${providerSha} -Dpact.verifier.publishResults=true
+            mvn clean test -DrunContractTests -DPACT_BROKER_USERNAME=${PACT_BROKER_USERNAME} -DPACT_BROKER_PASSWORD=${PACT_BROKER_PASSWORD} -DPACT_CONSUMER_TAG=${consumerTag} -DPROVIDER_SHA=${providerSha} -Dpact.provider.version=${providerSha} -Dpact.verifier.publishResults=true
            """
     }
 }

--- a/vars/runProviderContractTests.groovy
+++ b/vars/runProviderContractTests.groovy
@@ -8,6 +8,8 @@ def call() {
             string(credentialsId: 'pact_broker_username', variable: 'PACT_BROKER_USERNAME'),
             string(credentialsId: 'pact_broker_password', variable: 'PACT_BROKER_PASSWORD')]
     ) {
-        sh "mvn test -DrunContractTests -DPACT_CONSUMER_TAG=master -DPACT_BROKER_USERNAME=${PACT_BROKER_USERNAME} -DPACT_BROKER_PASSWORD=${PACT_BROKER_PASSWORD} -DPROVIDER_SHA=${commit} -Dpact.verifier.publishResults=true"
+        sh "mvn test -DrunContractTests -DPACT_CONSUMER_TAG=master -DPACT_BROKER_USERNAME=${PACT_BROKER_USERNAME} " +
+                "-DPACT_BROKER_PASSWORD=${PACT_BROKER_PASSWORD} -DPROVIDER_SHA=${commit} -Dpact.provider.version=${commit} " +
+                "-Dpact.verifier.publishResults=true"
     }
 }


### PR DESCRIPTION
The provider version set by the PROVIDER_SHA env var is actually a custom Pay
env var. The correct env var used by the pact libraries is
pact.provider.version.

@oswaldquek