### PR TITLE
bau: PACT_PROVIDER_SHA is no longer used

### DIFF
--- a/vars/runPactProviderTests.groovy
+++ b/vars/runPactProviderTests.groovy
@@ -13,7 +13,7 @@ def call( String providerProjectName,
             set -ue pipefail
             cd ${providerProjectName}
             export DOCKER_HOST=unix:///var/run/docker.sock
-            mvn clean test -DrunContractTests -DPACT_BROKER_USERNAME=${PACT_BROKER_USERNAME} -DPACT_BROKER_PASSWORD=${PACT_BROKER_PASSWORD} -DPACT_CONSUMER_TAG=${consumerTag} -DPROVIDER_SHA=${providerSha} -Dpact.provider.version=${providerSha} -Dpact.verifier.publishResults=true
+            mvn clean test -DrunContractTests -DPACT_BROKER_USERNAME=${PACT_BROKER_USERNAME} -DPACT_BROKER_PASSWORD=${PACT_BROKER_PASSWORD} -DPACT_CONSUMER_TAG=${consumerTag} -Dpact.provider.version=${providerSha} -Dpact.verifier.publishResults=true
            """
     }
 }

--- a/vars/runProviderContractTests.groovy
+++ b/vars/runProviderContractTests.groovy
@@ -9,7 +9,6 @@ def call() {
             string(credentialsId: 'pact_broker_password', variable: 'PACT_BROKER_PASSWORD')]
     ) {
         sh "mvn test -DrunContractTests -DPACT_CONSUMER_TAG=master -DPACT_BROKER_USERNAME=${PACT_BROKER_USERNAME} " +
-                "-DPACT_BROKER_PASSWORD=${PACT_BROKER_PASSWORD} -DPROVIDER_SHA=${commit} -Dpact.provider.version=${commit} " +
-                "-Dpact.verifier.publishResults=true"
+                "-DPACT_BROKER_PASSWORD=${PACT_BROKER_PASSWORD} -Dpact.provider.version=${commit} -Dpact.verifier.publishResults=true"
     }
 }


### PR DESCRIPTION
This has been superseded by pact.verifier.publishResults env var.

@oswaldquek