### PR TITLE
PP-4678: Update Docker compose definition

### DIFF
--- a/resources/cypress/cypress.yml
+++ b/resources/cypress/cypress.yml
@@ -12,7 +12,7 @@ services:
       PUBLIC_AUTH_URL: http://stub:8000/v1/frontend/auth
       ADMINUSERS_URL: http://stub:8000
       PRODUCTS_URL: http://stub:8000
-    mem_limit: 2G
+    mem_limit: 1G
     logging:
       driver: "json-file"
 
@@ -39,4 +39,4 @@ services:
     ports: 
       - 8000
       - 2525
-    mem_limit: 2G
+    mem_limit: 1G

--- a/resources/cypress/cypress.yml
+++ b/resources/cypress/cypress.yml
@@ -6,13 +6,13 @@ services:
     env_file: ${WORKSPACE}/test/cypress/test.env
     environment:
       PORT: 3000
-      CONNECTOR_URL: http://stub:8080
-      DIRECT_DEBIT_CONNECTOR_URL: http://stub:8080
-      PUBLIC_AUTH_BASE: http://stub:8080
-      PUBLIC_AUTH_URL: http://stub:8080/v1/frontend/auth
-      ADMINUSERS_URL: http://stub:8080
-      PRODUCTS_URL: http://stub:8080
-    mem_limit: 1G
+      CONNECTOR_URL: http://stub:8000
+      DIRECT_DEBIT_CONNECTOR_URL: http://stub:8000
+      PUBLIC_AUTH_BASE: http://stub:8000
+      PUBLIC_AUTH_URL: http://stub:8000/v1/frontend/auth
+      ADMINUSERS_URL: http://stub:8000
+      PRODUCTS_URL: http://stub:8000
+    mem_limit: 2G
     logging:
       driver: "json-file"
 
@@ -20,23 +20,23 @@ services:
     image: govukpay/cypress:6
     environment:
       CYPRESS_baseUrl: http://app_under_test:3000
+      CYPRESS_MOUNTEBANK_URL: http://stub:2525
+      CYPRESS_MOUNTEBANK_IMPOSTERS_PORT: 8000
     volumes:
       - ${WORKSPACE}/test/cypress:/app/test/cypress
       - ${WORKSPACE}/cypress.json:/app/cypress.json
       - ${WORKSPACE}/node_modules:/app/node_modules
       - ${WORKSPACE}/test/fixtures:/app/test/fixtures
+      - ${WORKSPACE}/app/models:/app/app/models
     logging:
       driver: "json-file"
     mem_limit: 2G
 
   stub:
-    image: pactfoundation/pact-stub-server:v0.0.10
-    entrypoint:
-      - "/app/pact-stub-server"
-      - "-p"
-      - "8080"
-      - "-d"
-      - "pacts"
-    volumes:
-      - ${WORKSPACE}/pacts:/app/pacts
-    mem_limit: 1G
+    image: govukpay/mountebank:1.16.0
+    logging:
+      driver: "json-file"
+    ports: 
+      - 8000
+      - 2525
+    mem_limit: 2G

--- a/vars/cypress.groovy
+++ b/vars/cypress.groovy
@@ -12,16 +12,13 @@ def call(String app = null, String tag = null) {
     env.TAG = (tag == null) ? "${commit}-${env.BUILD_NUMBER}" : tag
 
     sh """
-            docker-compose pull --ignore-pull-failures
-            docker-compose --project-name ${COMPOSE_PROJECT_NAME} up -d
+            docker-compose pull --ignore-pull-failures --quiet
+            docker-compose up -d
             docker-compose exec -T cypress ./ready.sh
             docker-compose exec -T cypress ./run-cypress.sh
        """
 }
 
 def cleanUp() {
-    sh """
-          docker-compose down || :
-          docker network rm ${env.COMPOSE_PROJECT_NAME} || :
-       """
+    sh "docker-compose down || :"
 }


### PR DESCRIPTION
* Includes environment variables required new Cypress testing
infrastructure
* Replaces stub pact server with mountebank

Updates Cypress docker compose infrastructure required by https://github.com/alphagov/pay-selfservice/pull/1111. Shouldn't be merged until self service is ready to accept this PR.