### PR TITLE
Simplify cypress cleanUp()

### DIFF
--- a/vars/cypress.groovy
+++ b/vars/cypress.groovy
@@ -13,7 +13,7 @@ def call(String app = null, String tag = null) {
 
     sh """
             docker-compose pull --ignore-pull-failures
-            docker-compose --project-name ${COMPOSE_PROJECT_NAME}  up  -d
+            docker-compose --project-name ${COMPOSE_PROJECT_NAME} up -d
             docker-compose exec -T cypress ./ready.sh
             docker-compose exec -T cypress ./run-cypress.sh
        """
@@ -21,9 +21,7 @@ def call(String app = null, String tag = null) {
 
 def cleanUp() {
     sh """
-          set +e
-          docker-compose down
-          docker network rm ${env.COMPOSE_PROJECT_NAME}
-          set -e
+          docker-compose down || :
+          docker network rm ${env.COMPOSE_PROJECT_NAME} || :
        """
 }


### PR DESCRIPTION
We can simplify these shell snippets a bit and ensure it always exits with a
zero status code.