### PR TITLE
Emit docker-compose logs after Cypress tests

### DIFF
--- a/vars/cypress.groovy
+++ b/vars/cypress.groovy
@@ -20,5 +20,8 @@ def call(String app = null, String tag = null) {
 }
 
 def cleanUp() {
-    sh "docker-compose down || :"
+    sh """
+            docker-compose logs || :
+            docker-compose down || :
+       """
 }


### PR DESCRIPTION
If containers fail to come up during Cypress tests, we don't know why because
the logs aren't captured.

Emit the logs