### PR TITLE
Fix the email address used when creating git tags

### DIFF
--- a/vars/gitTag.groovy
+++ b/vars/gitTag.groovy
@@ -7,7 +7,7 @@ def call(String tag, String annotation = null) {
       tag_cmd = tag_cmd.concat("-a -m '${annotation}'")
     }
 
-    sh "git config user.email payments-team@digital.cabinet-office.service.gov.uk"
+    sh "git config user.email payments-team@digital.cabinet-office.gov.uk"
     sh "git config user.name pay-jenkins"
 
     sh tag_cmd


### PR DESCRIPTION
Our email domain is digital.cabinet-office.gov.uk, not
digital.cabinet-office.service.gov.uk