### PR TITLE
Make contract tests more robust

### DIFF
--- a/vars/gitClone.groovy
+++ b/vars/gitClone.groovy
@@ -1,3 +1,0 @@
-String call(gitUri) {
-    sh(script: "git clone ${gitUri}", returnStdout: true)
-}

--- a/vars/runPactProviderTests.groovy
+++ b/vars/runPactProviderTests.groovy
@@ -2,18 +2,16 @@
 def call( String providerProjectName,
           String consumerTag) {
 
-    gitClone(gitUriFromProjectName(providerProjectName))
-    def providerSha = sh(script: "cd ${providerProjectName} && git rev-parse HEAD", returnStdout: true).trim()
-
     withCredentials([
             string(credentialsId: 'pact_broker_username', variable: 'PACT_BROKER_USERNAME'),
             string(credentialsId: 'pact_broker_password', variable: 'PACT_BROKER_PASSWORD')]
     ) {
         sh """
-            set -ue pipefail
+            set -ueo pipefail
+            rm -rf ${providerProjectName}
+            git clone ${gitUri}
             cd ${providerProjectName}
-            export DOCKER_HOST=unix:///var/run/docker.sock
-            mvn clean test -DrunContractTests -DPACT_BROKER_USERNAME=${PACT_BROKER_USERNAME} -DPACT_BROKER_PASSWORD=${PACT_BROKER_PASSWORD} -DPACT_CONSUMER_TAG=${consumerTag} -Dpact.provider.version=${providerSha} -Dpact.verifier.publishResults=true
+            DOCKER_HOST=unix:///var/run/docker.sock mvn clean test -DrunContractTests -DPACT_BROKER_USERNAME=${PACT_BROKER_USERNAME} -DPACT_BROKER_PASSWORD=${PACT_BROKER_PASSWORD} -DPACT_CONSUMER_TAG=${consumerTag} -Dpact.provider.version=$(git rev-parse HEAD) -Dpact.verifier.publishResults=true
            """
     }
 }


### PR DESCRIPTION
Sometimes we attempt to clone a repo over the top of an existing directory
which fails.

Make this more robust by removing the directory if it already exists.