### PR TITLE
Stop passing CALLER_BUILD_STATUS to run-tag-and-capture-notes-commit-based

### DIFF
--- a/vars/tagDeployment.groovy
+++ b/vars/tagDeployment.groovy
@@ -5,7 +5,6 @@ def call(String microservice, String aws_profile = "test", String tag = null) {
 
   build job: 'run-tag-and-capture-notes-commit-based',
     parameters: [
-      string(name: 'CALLER_BUILD_STATUS', value: 'success'),
       string(name: 'ENVIRONMENT', value: aws_profile),
       string(name: 'COMMIT_HASH', value: tag),
       string(name: 'SERVICE_TO_TAG', value: microservice)


### PR DESCRIPTION
This parameter is now unused, so we don't need to pass it in any more.

See https://github.com/alphagov/pay-chef/pull/842/files#diff-9a65505c55558afaaaa36e8ca6dbcf2aR12