### PR TITLE
Fix runPactProviderTests.groovy

### DIFF
--- a/vars/runPactProviderTests.groovy
+++ b/vars/runPactProviderTests.groovy
@@ -6,8 +6,8 @@ def call( String providerProjectName,
             string(credentialsId: 'pact_broker_username', variable: 'PACT_BROKER_USERNAME'),
             string(credentialsId: 'pact_broker_password', variable: 'PACT_BROKER_PASSWORD')]
     ) {
-        sh """
-            set -ue pipefail
+        sh """#!/bin/bash
+            set -ueo pipefail
             rm -rf ${providerProjectName}
             git clone git@github.com:alphagov/${providerProjectName}.git
             cd ${providerProjectName}

--- a/vars/runPactProviderTests.groovy
+++ b/vars/runPactProviderTests.groovy
@@ -7,7 +7,7 @@ def call( String providerProjectName,
             string(credentialsId: 'pact_broker_password', variable: 'PACT_BROKER_PASSWORD')]
     ) {
         sh """
-            set -ueo pipefail
+            set -ue pipefail
             rm -rf ${providerProjectName}
             git clone git@github.com:alphagov/${providerProjectName}.git
             cd ${providerProjectName}


### PR DESCRIPTION
Remove the "-o" option from "set" in the shell script as this causes the error 
/var/lib/jenkins/contract-tests-wp__tmp/durable-184b4bc3/script.sh: 2: set: Illegal option -o pipefail

I don't know much about bash, so it may be that we need to do something else to fix this, but currently its breaking builds.
From looking at this https://sipb.mit.edu/doc/safe-shell/ are we using dash in the build rather than bash?