### PR TITLE
BAU Remove mounting node modules in cypress container

### DIFF
--- a/resources/cypress/cypress.yml
+++ b/resources/cypress/cypress.yml
@@ -28,7 +28,6 @@ services:
     volumes:
       - ${WORKSPACE}/test/cypress:/app/test/cypress
       - ${WORKSPACE}/cypress.json:/app/cypress.json
-      - ${WORKSPACE}/node_modules:/app/node_modules
       - ${WORKSPACE}/test/fixtures:/app/test/fixtures
       - ${WORKSPACE}/app/models:/app/app/models
     logging:


### PR DESCRIPTION
* don't mount the node_modules from the workspace into the Cypress
container
* this totally defeats the point of having a Cypress container