### PR TITLE
Tag repositories inline in their build jobs

### DIFF
--- a/vars/tagDeployment.groovy
+++ b/vars/tagDeployment.groovy
@@ -1,12 +1,19 @@
 #!/usr/bin/env groovy
 
-def call(String microservice, String aws_profile = "test", String tag = null) {
-  tag = tag ?: gitCommit()
+def call() {
+  commit_hash = gitCommit()
 
-  build job: 'run-tag-and-capture-notes-commit-based',
-    parameters: [
-      string(name: 'ENVIRONMENT', value: aws_profile),
-      string(name: 'COMMIT_HASH', value: tag),
-      string(name: 'SERVICE_TO_TAG', value: microservice)
-    ]
+  date = new java.text.SimpleDateFormat("yyyy-MM-dd-HH:mm:ss").format(new Date())
+
+  latest_tag_components = sh(script: "git describe --abbrev=0 --match 'alpha_release-*'", returnStdout: true).trim().split('-')
+
+  latest_tag_str = latest_tag_components.size() > 1 ? latest_tag_components[1] : ''
+
+  new_release_number = latest_tag_str =~ /^[0-9]+$/ ? latest_tag_str.toInteger() + 1 : 1
+
+  tag_name = "alpha_release-${new_release_number}"
+
+  echo "Tagging ${commit_hash} with ${tag_name}"
+  sh "git tag -a '${tag_name}' '${commit_hash}' -m 'release candidate tag created on ${date}'"
+  sh "git push origin '${tag_name}'"
 }


### PR DESCRIPTION
Rather than call out to `run-tag-and-capture-notes-commit-based` as a separate
job, which clones a repo of scripts and then clones the repo of the application
we want to tag, we can just tag and push the repository we are within, inline
within the build job.

Convert our tagging script to groovy and inline it.

Disclaimer: I do not claim to be capable of producing idiomatic groovy code

This is in place of this job: https://github.com/alphagov/pay-chef/blob/master/cookbooks/pay-ci/templates/default/jenkins_jobs/tag-and-capture-notes-commit-based.groovy.erb
and this script: https://github.com/alphagov/pay-scripts/blob/master/deploy-pipeline/tagging/tag_and_capture_notes_commit_based.sh

The job and script are still used for tagging repositories following a database migration, which I think can be addressed separately