### PR TITLE
Revert "Tag repositories inline in their build jobs"

### DIFF
--- a/vars/tagDeployment.groovy
+++ b/vars/tagDeployment.groovy
@@ -1,19 +1,12 @@
 #!/usr/bin/env groovy
 
-def call() {
-  commit_hash = gitCommit()
+def call(String microservice, String aws_profile = "test", String tag = null) {
+  tag = tag ?: gitCommit()
 
-  date = new java.text.SimpleDateFormat("yyyy-MM-dd-HH:mm:ss").format(new Date())
-
-  latest_tag_components = sh(script: "git describe --abbrev=0 --match 'alpha_release-*'", returnStdout: true).trim().split('-')
-
-  latest_tag_str = latest_tag_components.size() > 1 ? latest_tag_components[1] : ''
-
-  new_release_number = latest_tag_str =~ /^[0-9]+$/ ? latest_tag_str.toInteger() + 1 : 1
-
-  tag_name = "alpha_release-${new_release_number}"
-
-  echo "Tagging ${commit_hash} with ${tag_name}"
-  sh "git tag -a '${tag_name}' '${commit_hash}' -m 'release candidate tag created on ${date}'"
-  sh "git push origin '${tag_name}'"
+  build job: 'run-tag-and-capture-notes-commit-based',
+    parameters: [
+      string(name: 'ENVIRONMENT', value: aws_profile),
+      string(name: 'COMMIT_HASH', value: tag),
+      string(name: 'SERVICE_TO_TAG', value: microservice)
+    ]
 }


### PR DESCRIPTION
Reverts alphagov/pay-jenkins-library#115

From https://build.ci.pymnt.uk/job/pay-cardid/job/master/8/console:
```
Scripts not permitted to use method groovy.lang.GroovyObject invokeMethod java.lang.String java.lang.Object (org.jenkinsci.plugins.workflow.cps.CpsClosure2 tagDeployment java.lang.String). Administrators can decide whether to approve or reject this signature.```