### PR TITLE
Revert "Tag repositories inline in their build jobs"

### DIFF
--- a/vars/tagDeployment.groovy
+++ b/vars/tagDeployment.groovy
@@ -1,20 +1,12 @@
 #!/usr/bin/env groovy
 
-// Preserve the previous method signature, even though we don't need any parameters any more
-def call(String ignored = null) {
-  commit_hash = gitCommit()
+def call(String microservice, String aws_profile = "test", String tag = null) {
+  tag = tag ?: gitCommit()
 
-  date = new java.text.SimpleDateFormat("yyyy-MM-dd-HH:mm:ss").format(new Date())
-
-  latest_tag_components = sh(script: "git describe --abbrev=0 --match 'alpha_release-*'", returnStdout: true).trim().split('-')
-
-  latest_tag_str = latest_tag_components.size() > 1 ? latest_tag_components[1] : ''
-
-  new_release_number = latest_tag_str =~ /^[0-9]+$/ ? latest_tag_str.toInteger() + 1 : 1
-
-  tag_name = "alpha_release-${new_release_number}"
-
-  echo "Tagging ${commit_hash} with ${tag_name}"
-  sh "git tag -a '${tag_name}' '${commit_hash}' -m 'release candidate tag created on ${date}'"
-  sh "git push origin '${tag_name}'"
+  build job: 'run-tag-and-capture-notes-commit-based',
+    parameters: [
+      string(name: 'ENVIRONMENT', value: aws_profile),
+      string(name: 'COMMIT_HASH', value: tag),
+      string(name: 'SERVICE_TO_TAG', value: microservice)
+    ]
 }


### PR DESCRIPTION
Reverts alphagov/pay-jenkins-library#117

This still doesn't work. Reverting whilst I investigate.

```
[Pipeline] build (Building trigger-deploy-notification)
09:16:01  Scheduling project: trigger-deploy-notification
09:16:01  + git describe --abbrev=0 --match alpha_release-*
09:16:01  fatal: No names found, cannot describe anything.
```