### PR TITLE
Hardcode arguments to runSmokeTest

### DIFF
--- a/vars/runCardSmokeTest.groovy
+++ b/vars/runCardSmokeTest.groovy
@@ -1,9 +1,5 @@
 #!/usr/bin/env groovy
 
-def call(String aws_profile = "test", boolean promoted_env = true) {
-  runSmokeTest(
-          "uk.gov.pay.endtoend.categories.SmokeCardPayments",
-          aws_profile,
-          promoted_env
-  )
+def call() {
+  runSmokeTest("uk.gov.pay.endtoend.categories.SmokeCardPayments")
 }

--- a/vars/runDirectDebitSmokeTest.groovy
+++ b/vars/runDirectDebitSmokeTest.groovy
@@ -1,9 +1,5 @@
 #!/usr/bin/env groovy
 
-def call(String aws_profile = "test", boolean promoted_env = true) {
-  runSmokeTest(
-          "uk.gov.pay.endtoend.categories.SmokeDirectDebitPayments",
-          aws_profile,
-          promoted_env
-  )
+def call() {
+  runSmokeTest("uk.gov.pay.endtoend.categories.SmokeDirectDebitPayments")
 }

--- a/vars/runProductsSmokeTest.groovy
+++ b/vars/runProductsSmokeTest.groovy
@@ -1,9 +1,5 @@
 #!/usr/bin/env groovy
 
-def call(String aws_profile = "test", boolean promoted_env = true) {
-  runSmokeTest(
-          "uk.gov.pay.endtoend.categories.SmokeProducts",
-          aws_profile,
-          promoted_env
-  )
+def call() {
+  runSmokeTest("uk.gov.pay.endtoend.categories.SmokeProducts")
 }

--- a/vars/runSmokeTest.groovy
+++ b/vars/runSmokeTest.groovy
@@ -1,11 +1,10 @@
 #!/usr/bin/env groovy
 
-def call(String smoke_tags, String aws_profile = "test", boolean promoted_env = false) {
-
+def call(String smoke_tags) {
   build job: 'run-smoke-test',
     parameters: [
-      string(name: 'AWS_PROFILE', value: aws_profile),
-      booleanParam(name: 'PROMOTED_ENV', value: promoted_env),
+      string(name: 'AWS_PROFILE', value: 'test'),
+      booleanParam(name: 'PROMOTED_ENV', value: true),
       string(name: 'SMOKE_TAGS', value: smoke_tags)
     ]
 }


### PR DESCRIPTION
We never call run*SmokeTest with any arguments, so remove them and hardcode the
values instead.