### PR TITLE
Remove extra parameters from run-smoke-test call

### DIFF
--- a/vars/runSmokeTest.groovy
+++ b/vars/runSmokeTest.groovy
@@ -3,8 +3,6 @@
 def call(String smoke_tags) {
   build job: 'run-smoke-test',
     parameters: [
-      string(name: 'AWS_PROFILE', value: 'test'),
-      booleanParam(name: 'PROMOTED_ENV', value: true),
       string(name: 'SMOKE_TAGS', value: smoke_tags)
     ]
 }


### PR DESCRIPTION
The defaults for this job are fine, we don't need to pass in these extra
parameters.