### PR TITLE
Remove unused parameters from tagDeployment

### DIFF
--- a/vars/tagDeployment.groovy
+++ b/vars/tagDeployment.groovy
@@ -1,12 +1,10 @@
 #!/usr/bin/env groovy
 
-def call(String microservice, String aws_profile = "test", String tag = null) {
-  tag = tag ?: gitCommit()
-
+def call(String microservice) {
   build job: 'run-tag-and-capture-notes-commit-based',
     parameters: [
-      string(name: 'ENVIRONMENT', value: aws_profile),
-      string(name: 'COMMIT_HASH', value: tag),
+      string(name: 'ENVIRONMENT', value: 'test'),
+      string(name: 'COMMIT_HASH', value: gitCommit()),
       string(name: 'SERVICE_TO_TAG', value: microservice)
     ]
 }


### PR DESCRIPTION
Only the first parameter is ever used. Remove the other two & hardcode them.

See https://github.com/search?p=1&q=org%3Aalphagov+tagdeployment&type=Code for
proof.