### PR TITLE
PP-5670: Add CONSUMER property to the maven run

### DIFF
--- a/vars/runPactProviderTests.groovy
+++ b/vars/runPactProviderTests.groovy
@@ -1,6 +1,7 @@
 #!/usr/bin/env groovy
 def call( String providerProjectName,
-          String consumerTag) {
+          String consumerTag,
+          String consumer = '') {
 
     withCredentials([
             string(credentialsId: 'pact_broker_username', variable: 'PACT_BROKER_USERNAME'),
@@ -12,7 +13,7 @@ def call( String providerProjectName,
             git clone git@github.com:alphagov/${providerProjectName}.git
             cd ${providerProjectName}
             export DOCKER_HOST=unix:///var/run/docker.sock
-            mvn clean test -DrunContractTests -DPACT_BROKER_USERNAME=${PACT_BROKER_USERNAME} -DPACT_BROKER_PASSWORD=${PACT_BROKER_PASSWORD} -DPACT_CONSUMER_TAG=${consumerTag} -Dpact.provider.version=\$(git rev-parse HEAD) -Dpact.verifier.publishResults=true
+            mvn clean test -DrunContractTests -DPACT_BROKER_USERNAME=${PACT_BROKER_USERNAME} -DPACT_BROKER_PASSWORD=${PACT_BROKER_PASSWORD} -DPACT_CONSUMER_TAG=${consumerTag} -Dpact.provider.version=\$(git rev-parse HEAD) -Dpact.verifier.publishResults=true -DCONSUMER=${consumer}
            """
     }
 }


### PR DESCRIPTION
The default CONSUMER value is blank which will mean by default all tests will be run at
the provider (see
https://github.com/alphagov/pay-connector/blob/master/src/test/java/uk/gov/pay/connector/pact/ContractTestSuite.java#L29-L31)