### PR TITLE
PP-5889 Remove frontend from docker build/test step

### DIFF
--- a/resources/cypress/cypress.yml
+++ b/resources/cypress/cypress.yml
@@ -22,7 +22,7 @@ services:
       driver: "json-file"
 
   cypress:
-    image: govukpay/cypress:6
+    image: cypress/included:3.2.0
     environment:
       CYPRESS_baseUrl: http://app_under_test:3000
       CYPRESS_MOUNTEBANK_URL: http://stub:2525

--- a/vars/buildAppWithMetrics.groovy
+++ b/vars/buildAppWithMetrics.groovy
@@ -23,7 +23,7 @@ def call(body) {
         build_flags = "--no-cache --pull"
     }
 
-    if (app == "frontend" || app == "selfservice" || app == 'products-ui' || app == 'directdebit-frontend') {
+    if (app == "selfservice" || app == 'products-ui' || app == 'directdebit-frontend') {
         def buildImageName = "build-and-test-${app}"
         sh "docker build --file docker/build_and_test.Dockerfile -t ${buildImageName}:${version} ."
         withCredentials([


### PR DESCRIPTION
Our current CI pipeline treats node apps differently and kicks off a build/ pact/ test/ lint step all using a completely different Dockerfile than the main repositories. 

Propose removing this in favour of using the repo Dockerfile. 

Advantages: 
* Local, CI and production should all aim to use as similar a container as possible 
* Reduce number of places we have to update version dependencies
* Prepare for our shiny containerised future