### PR TITLE
PP-6008 Use new mountebank docker image

### DIFF
--- a/resources/cypress/cypress.yml
+++ b/resources/cypress/cypress.yml
@@ -38,10 +38,10 @@ services:
     mem_limit: 2G
 
   stub:
-    image: govukpay/mountebank:1.16.0
+    image: govukpay/mountebank:2.1.2
     logging:
       driver: "json-file"
-    ports: 
+    ports:
       - 8000
       - 2525
     mem_limit: 1G


### PR DESCRIPTION
Use new mountebank docker image where the command specifies the `--debug` option. This allows us to verify that stubs are called.