### PR TITLE
Revert "BAU Improve branchname method"

### DIFF
--- a/vars/gitBranchName.groovy
+++ b/vars/gitBranchName.groovy
@@ -1,3 +1,3 @@
 String call() {
-  sh(script: "git symbolic-ref -q HEAD --short", returnStdout: true).trim()
+  sh(script: "git rev-parse HEAD | git branch -a --contains | sed -n 2p | cut -d'/' -f 3", returnStdout: true).trim()
 }


### PR DESCRIPTION
Reverts alphagov/pay-jenkins-library#110 because it’s breaking all our builds!