### PR TITLE
PP-6763 - Remove direct debit Jenkins library function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 *.orig
 *.swp
+*.iml

--- a/vars/runDirectDebitSmokeTest.groovy
+++ b/vars/runDirectDebitSmokeTest.groovy
@@ -1,5 +1,0 @@
-#!/usr/bin/env groovy
-
-def call() {
-  runSmokeTest("smoke-directdebit")
-}


### PR DESCRIPTION
Description:
- Since no Jenkins pipeline is now calling the runDirectDebit library function it is unused and so can be safely deleted