### PR TITLE
BAU Add Webhooks to Jenkins cypress env config

### DIFF
--- a/resources/cypress/cypress.yml
+++ b/resources/cypress/cypress.yml
@@ -15,6 +15,7 @@ services:
       ADMINUSERS_URL: http://stub:8000
       PRODUCTS_URL: http://stub:8000
       LEDGER_URL: http://stub:8000
+      WEBHOOKS_URL: http://stub:8000
       ZENDESK_URL: http://stub:8000
       WORLDPAY_3DS_FLEX_DDC_TEST_URL: http://stub:8000/shopper/3ds/ddc.html
     mem_limit: 1G


### PR DESCRIPTION
Cypress browser tests are failing on Jenkins but passing on other
environments. It looks like these env vars override the default test env
to make it work specifically on Jenkins networking setup.

Add an entry to point the tests at the correct stub server for webhooks.