### PR TITLE
BAU Prevent Cypress from polluting Jenkins logs

### DIFF
--- a/resources/cypress/cypress.yml
+++ b/resources/cypress/cypress.yml
@@ -33,6 +33,7 @@ services:
   cypress:
     image: cypress/included:${CYPRESS_VERSION:-"3.1.5"}
     environment:
+      NO_COLOR: 1
       CYPRESS_BASE_URL: http://app_under_test:3000
       CYPRESS_MOUNTEBANK_URL: http://stub:2525
       CYPRESS_MOUNTEBANK_IMPOSTERS_PORT: 8000


### PR DESCRIPTION
### WHAT 
Jenkins logs are difficult to read during stages that require Cypress as the colour codes are printed literally. 

By setting `NO_COLOR` to 1 this should prevent Cypress trying to colourise the logging output.